### PR TITLE
added actual links to the navbar

### DIFF
--- a/app/views/layouts/application.html.erb
+++ b/app/views/layouts/application.html.erb
@@ -20,10 +20,10 @@
       <div class="collapse navbar-collapse" id="navbarNav">
         <ul class="navbar-nav">
           <li class="nav-item">
-            <a class="nav-link" href="#">Rent a Seaplane</a>
+            <%= link_to "Rent a Seaplane", seaplanes_path, class: "nav-link" %>
           </li>
           <li class="nav-item">
-            <a class="nav-link" href="#">List your Seaplane</a>
+            <%= link_to "List your Seaplane", new_seaplane_path, class: "nav-link" %>
           </li>
           <% if user_signed_in? %>
           <li class="nav-item dropdown">


### PR DESCRIPTION
The links in the navbar all works now.
Here is before login:
![image](https://user-images.githubusercontent.com/33075306/141981007-b31274c6-b11f-4ca0-9367-d4fbd23f87fc.png)

If I click on either see the planes or add new planes it will prompt me to login:
![image](https://user-images.githubusercontent.com/33075306/141981197-a8067424-1c98-426f-9abf-1f528c40bd27.png)

Once logged in, the list my plane file returns a form which is expected:
![image](https://user-images.githubusercontent.com/33075306/141981278-c9aa8b9d-6538-4f54-840a-ecafc47157f3.png)

Rent a seaplane button goes to the index link which is expected:
![image](https://user-images.githubusercontent.com/33075306/141981391-28911f94-6ab6-4dd5-ba79-33889cc44137.png)
