### PR TITLE
making the footer elements more visible

### DIFF
--- a/app/assets/stylesheets/components/_footer.scss
+++ b/app/assets/stylesheets/components/_footer.scss
@@ -2,27 +2,26 @@
   background: rgb(20,127,251);
   display: flex;
   align-items: center;
-    justify-content: space-between;
+  justify-content: space-between;
   height: 100px;
   padding: 0px 50px;
   color: rgb(255, 255, 255);
   position: fixed; bottom: 0;
   width:100%;
-
 }
 .footer-links {
   display: flex;
   align-items: center;
 }
 .footer-links a {
-  color: black;
-  opacity: 0.15;
+  color: white;
+  opacity: 1;
   text-decoration: none;
   font-size: 24px;
   padding: 0px 10px;
 }
 .footer-links a:hover {
-  opacity: 1;
+  opacity: 0.5;
 }
 .footer .fa-heart {
   color: #D23333;


### PR DESCRIPTION
Making the footer font-awesome elements more visible by changing font color to white:
![image](https://user-images.githubusercontent.com/33075306/142030195-02b04820-969c-45ec-aef4-cee255620470.png)
